### PR TITLE
Add support for Snippet Spec V2 and more optimised encryption stacks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,7 +52,7 @@ func Load() {
 			Overrides: make(map[string]string),
 		},
 		S3: S3{
-			Bucket: viper.GetString("S3_BUCKET"),
+			Bucket:   viper.GetString("S3_BUCKET"),
 			Provider: viper.GetString("S3_PROVIDER"),
 		},
 		Crypto: Crypto{

--- a/src/main.go
+++ b/src/main.go
@@ -19,9 +19,8 @@ func main() {
 	config.Load()
 	utils.InitLogger(config.Cfg)
 
-
 	sp := storageprovider.InitS3StorageProvider()
-	
+
 	sc := model.NewMongoSnippetController(sp)
 	svc := service.NewSnippetService(sc, config.Cfg.Svc)
 

--- a/src/service/preprocessor.go
+++ b/src/service/preprocessor.go
@@ -28,7 +28,7 @@ func populateChan(idSize int, c chan types.EncryptionStack) {
 			c <- stacksArr[ptr]
 			ptr++
 		}
-		if !genetating && (ptr >= stacksLen - 5 || ptr == -1) {
+		if !genetating && (ptr >= stacksLen-5 || ptr == -1) {
 			genetating = true
 			go func() {
 				for i := 0; i < stacksLen; i++ {

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -129,7 +129,7 @@ func (s *serviceImpl) FetchSnippet(id string) (*types.Snippet, error) {
 	}
 
 	decryptedSnippet := utils.Decrypt(ciphertext, salt, iv, []byte(id))
-	
+
 	var snippet types.Snippet
 	if snippetSpec.Version == "v1" {
 		decompressedJSON := utils.Inflate(decryptedSnippet)

--- a/src/service/service.go
+++ b/src/service/service.go
@@ -48,8 +48,11 @@ func (s *serviceImpl) CreateSnippet(snippet types.Snippet, ephemeral bool) (stri
 		keys = <-encryptionKeys
 	}
 
-	snippet.Metadata["id"] = keys.ID
-	rawSnippet, _ := json.Marshal(snippet)
+	snippet.Metadata.ID = keys.ID
+	rawSnippet, err := json.Marshal(snippet)
+	if err != nil {
+		return "", err
+	}
 
 	// Deflate snippet -> Encrypt snippet -> encode snippet
 	compressedSnippet := utils.Defalte(rawSnippet)

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -16,6 +16,12 @@ type SnippetSpec struct {
 }
 
 type Snippet struct {
-	Data     string                 `json:"data"`
-	Metadata map[string]interface{} `json:"metadata"`
+	Metadata Metadata `json:"metadata"`
+	Data     string   `json:"data"`
+}
+
+type Metadata struct {
+	Ephemeral bool   `json:"ephemeral"`
+	ID        string `json:"id"`
+	Language  string `json:"language"`
 }

--- a/src/types/types.go
+++ b/src/types/types.go
@@ -1,16 +1,16 @@
 package types
 
 type EncryptionStack struct {
-	ID   string
+	Salt *[32]byte
 	Key  []byte
 	Hash string
-	Salt *[32]byte
+	ID   string
 }
 
 type SnippetSpec struct {
+	Ephemeral  bool   `json:"ephemeral"`
 	Version    string `json:"version"`
 	Keysalt    string `json:"keysalt"`
-	Ephemeral  bool   `json:"ephemeral"`
 	Initvector string `json:"initvector"`
 	Ciphertext string `json:"ciphertext"`
 }

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -2,9 +2,9 @@ package utils
 
 import (
 	"bytes"
+	"compress/zlib"
 	"io/ioutil"
 	"strings"
-	"compress/zlib"
 
 	"github.com/leonklingele/passphrase"
 )

--- a/src/view/http/contract/contract.go
+++ b/src/view/http/contract/contract.go
@@ -25,4 +25,3 @@ type Metadata struct {
 }
 
 var CS CreateSnippet
-

--- a/src/view/http/handler/snippet/snippet.go
+++ b/src/view/http/handler/snippet/snippet.go
@@ -53,9 +53,9 @@ func Create(svc service.Service, cfg *config.HTTPServerConfig) http.HandlerFunc 
 
 		snippet := types.Snippet{
 			Data: data.Data,
-			Metadata: map[string]interface{}{
-				"ephemeral": data.Metadata.Ephemeral,
-				"language":  data.Metadata.Language,
+			Metadata: types.Metadata{
+				Ephemeral: data.Metadata.Ephemeral,
+				Language:  data.Metadata.Language,
 			},
 		}
 

--- a/src/view/http/handler/snippet/snippet.go
+++ b/src/view/http/handler/snippet/snippet.go
@@ -41,9 +41,9 @@ func CreateE2E(svc service.Service, cfg *config.HTTPServerConfig) http.HandlerFu
 			URL: fmt.Sprintf(cfg.GetBaseURL(), snippetID),
 		}
 
-		raw, _ := json.Marshal(resp)
 		req.Header.Add("Content-Type", "application/json")
-		w.Write(raw)
+		e := json.NewEncoder(w)
+		e.Encode(resp)
 	}
 }
 
@@ -70,9 +70,9 @@ func Create(svc service.Service, cfg *config.HTTPServerConfig) http.HandlerFunc 
 			URL: fmt.Sprintf(cfg.GetBaseURL(), snippetID),
 		}
 
-		raw, _ := json.Marshal(resp)
 		req.Header.Add("Content-Type", "application/json")
-		w.Write(raw)
+		e := json.NewEncoder(w)
+		e.Encode(resp)
 	}
 }
 

--- a/src/view/http/handler/snippet/snippet.go
+++ b/src/view/http/handler/snippet/snippet.go
@@ -94,13 +94,12 @@ func Get(svc service.Service, responseType string) http.HandlerFunc {
 		}
 
 		if responseType == "raw" {
-			x := new(types.Snippet)
-			json.Unmarshal(snippet.Snippet, &x)
-			w.Write([]byte(x.Data))
+			w.Write([]byte(snippet.Data))
 			return
 		}
 
 		req.Header.Add("Content-Type", "application/json")
-		w.Write(snippet.Snippet)
+		e := json.NewEncoder(w)
+		e.Encode(snippet)
 	}
 }


### PR DESCRIPTION
Spec v2 changes how snippet object is handled in create and fetch flows, specifially:
during creation:
- Compress user Snippet instead of entire object then B64 encode it
during fetch:
- After decryption, unmarshal data to snippet to object then run B64 decode and decompression on snippet's data field

Advantages to this approach:
- Compression is cleaner and more effective as we only want to target user snippet; compressing JSON doesn't have any clear benefit and might be less effective due to noise
- Running B64 on compressed data prevents JSON Marshal from producing a large output for non-text data due to encoding challenges (think: escapes) thus improving memory usage and reducing size of these json encoded objects quite dramatically

Backwards compatibility is preserved for existing v1 snippets; however no new snippets will be created with it. REST API spec remains unchanged as it only relies on snippet object and that remains changed


A more optimized implementation of Encryption Stacks is also introduced, now we generate more stacks and store them in an array so we don't do compute after every request and rather only after a critical point